### PR TITLE
Bump the priority for our wp_enqueue_scripts action to always come after Alcatraz script registration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@ define( 'ALCATRAZ_CHILD_VERSION', '1.0.0' );
 define( 'ALCATRAZ_CHILD_PATH', trailingslashit( get_stylesheet_directory() ) );
 define( 'ALCATRAZ_CHILD_URL', trailingslashit( get_stylesheet_directory_uri() ) );
 
-add_action( 'wp_enqueue_scripts', 'alcatraz_child_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', 'alcatraz_child_enqueue_scripts', 15 );
 /**
  * Enqueue scripts and stylesheets.
  */


### PR DESCRIPTION
I was spinning up a site with Alcatraz Child today and wasn't getting the Alcatraz fonts when I added `wp_enqueue_script( 'alcatraz-fonts' )` on the default priority of 10. The reason why is because the child theme is processed first, so if both Alcatraz and Alcatraz Child enqueue/register at priority 10 then the Alcatraz Child enqueue function fires first, but in this situation `wp_register_script( 'alcatraz-fonts' )` has not yet been called.

This PR bumps the priority to 15 for the Alcatraz Child enqueue, which will ensure that it always loads after all Alcatraz scripts and styles have been registered.
